### PR TITLE
Resolves #4, Reintroduce the CompositeConverter

### DIFF
--- a/lib/asciidoctor/core_ext/factory.rb
+++ b/lib/asciidoctor/core_ext/factory.rb
@@ -49,7 +49,8 @@ module Asciidoctor
         unless defined? ::Asciidoctor::Converter::CompositeConverter
           require 'asciidoctor/converter/composite'.to_s
         end
-        TemplateConverter.new backend, opts[:template_dirs], opts
+        template_converter = TemplateConverter.new backend, opts[:template_dirs], opts
+        CompositeConverter.new backend, template_converter, base_converter
       end
     end
   end

--- a/lib/asciidoctor/core_ext/template.rb
+++ b/lib/asciidoctor/core_ext/template.rb
@@ -11,6 +11,10 @@ module Asciidoctor
       end
     end
 
+    def handles? name
+      !(resolve_template name).nil?
+    end
+
     def resolve_template name
       path_resolver = PathResolver.new
       backend = @backend


### PR DESCRIPTION
Note that the following commit is needed in Asciidoctor.js: https://github.com/asciidoctor/asciidoctor.js/pull/219/commits/dfeadfff60029e61d83de74dfbfa7f841297d527
Otherwise the composite class is not found.
